### PR TITLE
Fingerprint the stylesheet to defeat stale CDN caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - id: pages
         uses: actions/configure-pages@v5
 
-      - run: bundle exec jekyll build --config=_config.yml
+      - run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ mise exec ruby@3.3 -- bundle install
 
 ## Local development
 
-Serve with live reload (some dev-only nav links appear via `_config-dev.yml`):
+Serve with live reload (source maps are generated in this mode):
 
 ```sh
-mise exec ruby@3.3 -- bundle exec jekyll serve --config=_config.yml,_config-dev.yml
+mise exec ruby@3.3 -- bundle exec jekyll serve
 ```
 
 Then open <http://localhost:4000>.

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,4 +1,0 @@
-dev: true
-
-# CSS style + sourcemaps both come from _config.yml (sourcemap: development),
-# which generates source maps when JEKYLL_ENV=development (i.e. local serve).

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,5 +1,4 @@
 dev: true
 
-sass:
-  style: :nested
-  sourcemap: :inline
+# CSS style + sourcemaps both come from _config.yml (sourcemap: development),
+# which generates source maps when JEKYLL_ENV=development (i.e. local serve).

--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,9 @@ url:  https://francois.monniot.eu
 
 sass:
   style: compressed
+  # Sourcemaps only when JEKYLL_ENV=development (i.e. local serve), never on the
+  # public production build where they'd just be dead weight.
+  sourcemap: development
 
 defaults:
   -

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <meta name="author" content="{{ site.profile.name }}" />
   <meta name="description" content="{{ page.description | default: site.profile.bio }}" />
 
-  <link rel="stylesheet" type="text/css" href="/css/styles.css" />
+  <link rel="stylesheet" type="text/css" href="{{ site.css_path }}" />
 
   <link rel="icon"      type="image/svg+xml"        href="/images/favicon.svg" />
   <link rel="sitemap"   type="application/xml"     href="/sitemap.xml" title="Sitemap" />

--- a/_plugins/fingerprint.rb
+++ b/_plugins/fingerprint.rb
@@ -1,0 +1,33 @@
+# Fingerprints the compiled stylesheet so its filename changes whenever the
+# source changes. The site is fronted by Cloudflare, which caches CSS for hours
+# under a fixed filename — that's how a redesign can ship correct HTML while the
+# old (or missing) stylesheet lingers at the edge, rendering pages unstyled.
+# A content-derived filename means a new build is a new URL, so there is nothing
+# stale to serve.
+#
+# We hash the SCSS source and rename the compiled page's basename to
+# styles-<hash>, then expose `site.css_path` for layouts to link. Editing
+# css/styles.scss changes the hash, hence the filename.
+#
+# We rename `basename` rather than setting a `permalink`: jekyll-sass-converter
+# builds the companion SourceMapPage from the css page's *basename* and shares
+# its `data` hash, so a permalink would leak onto the source map and make both
+# files resolve to the same URL (the map would overwrite the CSS). Renaming the
+# basename instead keeps styles.css, styles.css.map, and the sourceMappingURL
+# comment consistently fingerprinted.
+
+require "digest"
+
+STYLESHEET_SOURCE = "css/styles.scss".freeze
+
+Jekyll::Hooks.register :site, :post_read do |site|
+  source_path = File.join(site.source, STYLESHEET_SOURCE)
+  next unless File.exist?(source_path)
+
+  digest = Digest::MD5.file(source_path).hexdigest[0, 12]
+
+  page = site.pages.find { |p| p.path == STYLESHEET_SOURCE }
+  page.basename = "styles-#{digest}" if page
+
+  site.config["css_path"] = "/css/styles-#{digest}.css"
+end


### PR DESCRIPTION
### Why

After the spine redesign merged, the deployed site rendered as unstyled
black-on-white even though the build succeeded and `/css/styles.css` was
served correctly. Root cause: the site is fronted by **Cloudflare**, which
caches CSS for hours (`cache-control: max-age=14400`) under a **fixed
filename** while HTML is served uncached. During the redesign deploy window
the new HTML loaded against a stale/missing stylesheet at the edge, so the
page came up unstyled until the cache expired.

### What

Fingerprint the compiled CSS by content hash — `styles-<hash>.css` — so every
meaningful change produces a new URL with nothing stale to serve. No manual
cache purges needed on future redesigns.

- **`_plugins/fingerprint.rb`** (new) — hashes `css/styles.scss`, renames the
  compiled page's `basename` to `styles-<hash>`, and exposes `site.css_path`.
  It renames the *basename* rather than setting a `permalink` on purpose:
  `jekyll-sass-converter` shares the CSS page's `data` hash with its
  `SourceMapPage`, so a permalink leaks onto the source map and both files
  resolve to the same URL (the map overwrites the CSS). Renaming the basename
  keeps the `.css`, `.css.map`, and `sourceMappingURL` comment aligned.
- **`_layouts/default.html`** — link `{{ site.css_path }}` instead of the
  hardcoded `/css/styles.css`.
- **`_config.yml`** — `sass: { style: compressed, sourcemap: development }`.
  Source maps now generate only in local dev (`JEKYLL_ENV=development`), never
  on the public production build.
- **`.github/workflows/deploy.yml`** — simplified the build back to plain
  `bundle exec jekyll build` (the `--config`/`--baseurl` flags were no-ops).
- **Removed `_config-dev.yml`** — after moving source maps to the env-aware
  setting, it held only a `dev: true` flag that nothing read. Its
  `style: :nested` / `sourcemap: :inline` values were also silently invalid in
  `jekyll-sass-converter` 3.x (the bad `:inline` is what broke dev source maps).
  Local serving now uses the default config.

### Testing

- **Production** (`JEKYLL_ENV=production jekyll build`) → `styles-<hash>.css`
  only (compressed, no map, no `sourceMappingURL`); HTML links to it.
- **Dev** (`jekyll serve`) → `styles-<hash>.css` + matching `styles-<hash>.css.map`
  with a correct `sourceMappingURL`; full SCSS-level debugging in devtools.
